### PR TITLE
Don't remove footways that can be biked on

### DIFF
--- a/omc-mkgmap-style/lines
+++ b/omc-mkgmap-style/lines
@@ -27,14 +27,6 @@ highway=* & name=* {set mkgmap:street='${name}'}
 # Mark highways with the toll flag
 highway=* & (toll=yes | toll=true) {set mkgmap:toll=yes}
 
-# OpenMapChest
-# Remove sidewalks
-highway=footway & footway=sidewalk { deletealltags }
-highway=footway & footway=crossing { deletealltags }
-# Remove private driveways
-access=private & highway=service & service=driveway { deletealltags }
-# OpenMapChest
-
 # Hide proposed ways
 highway=proposed | highway=proposal | highway=planned | highway~'.*proposed.*' {delete highway; delete junction}
 # Hide removed ways
@@ -123,10 +115,20 @@ highway=path & (designation=permissive_bridleway | designation=public_bridleway)
     {set highway=bridleway; add foot=yes}
 highway=path & (designation=permissive_footpath | designation=public_footpath)
     {set highway=footway; add foot=designated}
+highway=footway & snowplowing!=no & (bicycle=yes | bicycle=designated | bicycle=permissive | bicycle=official | cycleway=lane)
+    {set highway=cycleway; set bicycle=yes; set foot=yes}
 highway=path & snowplowing!=no & (bicycle=designated | bicycle=permissive | bicycle=official | cycleway=lane)
     {set highway=cycleway; add foot=yes}
 highway=path & foot=designated
     {set highway=footway}
+
+# OpenMapChest
+# Remove sidewalks
+highway=footway & footway=sidewalk { deletealltags }
+highway=footway & footway=crossing { deletealltags }
+# Remove private driveways
+access=private & highway=service & service=driveway { deletealltags }
+# OpenMapChest
 
 leisure=track & area!=yes {name '${name} (${sport})' | '${sport}'} [0x30 resolution 22]
 man_made=pier | man_made=piste:halfpipe {add highway=footway; name '${ref} ${name}' | '${ref}' | '${name}'}


### PR DESCRIPTION
Some ways, such as https://www.openstreetmap.org/way/987797955 (#1) have `highway=footway`, `footway=crossing`, `bicycle=yes`, and make up important segments of bike routes. Currently, though, we strip these out as we consider them sidewalks.

To fix that, incorporate the bikable footway to cycleway conversion that's already in [upstream][1] and then move our sidewalk removal logic to after that conversion happens. This way, we'll still remove sidewalks that aren't bikable, but the ones that are won't be footways by the time we try to remove them.

[1]: https://github.com/openstreetmap/mkgmap/blob/453ed3a706a6dd0f05d1b78d89b688d59cad997e/resources/styles/default/lines#L61-L62